### PR TITLE
Removed bugged package pkg-resources==0.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ matplotlib==3.2.2
 numpy==1.19.0
 opencv-python==4.2.0.34
 Pillow==7.1.2
-pkg-resources==0.0.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 PyYAML==5.3.1


### PR DESCRIPTION
As mentioned in these discussion, pkg-resources is a bug derived from executing `pip freeze` on Ubuntu. It breaks dependency installations on MacOSX `pip3 install -r requirements.txt` with the following error `ERROR: Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements.txt (line 9)) (from versions: none)`

This file is not required and is an artefact of an old issue, hence removed.