### PR TITLE
delete "view_img=True" in track.py

### DIFF
--- a/track.py
+++ b/track.py
@@ -94,11 +94,9 @@ def detect(opt, save_img=False):
     # Set Dataloader
     vid_path, vid_writer = None, None
     if webcam:
-        view_img = True
         cudnn.benchmark = True  # set True to speed up constant image size inference
         dataset = LoadStreams(source, img_size=imgsz)
     else:
-        view_img = True
         save_img = True
         dataset = LoadImages(source, img_size=imgsz)
 


### PR DESCRIPTION
I deleted "view_img=True" in script because it is designated by parser.
If something wrong, I am sorry.