### PR TITLE
Two errors were changed

### DIFF
--- a/deep_sort_pytorch/deep_sort/deep/feature_extractor.py
+++ b/deep_sort_pytorch/deep_sort/deep/feature_extractor.py
@@ -34,8 +34,7 @@ class Extractor(object):
         """
         def _resize(im, size):
             return cv2.resize(im.astype(np.float32)/255., size)
-
-        im_batch = torch.cat([self.norm(_resize(im, self.size)).unsqueeze(
+        im_batch = torch.cat([self.norm(cv2.cvtColor(_resize(im, self.size), cv2.COLOR_GRAY2BGR)).unsqueeze(
             0) for im in im_crops], dim=0).float()
         return im_batch
 

--- a/track.py
+++ b/track.py
@@ -108,7 +108,7 @@ def detect(opt):
         dt[0] += t2 - t1
 
         # Inference
-        visualize = increment_path(save_dir / Path(path).stem, mkdir=True) if opt.visualize else False
+        visualize = increment_path(save_path / Path(path).stem, mkdir=True) if opt.visualize else False
         pred = model(img, augment=opt.augment, visualize=visualize)
         t3 = time_sync()
         dt[1] += t3 - t2


### PR DESCRIPTION
1、
file: feature_extractor.py：
err reasons: RuntimeError: output with shape [1, 128, 64] doesn't match the broadcast shape [3, 128, 64]
correct :  change 
  im_batch = torch.cat([self.norm(_resize(im, self.size)).unsqueeze(
            0) for im in im_crops], dim=0).float()
to
    im_batch = torch.cat([self.norm(cv2.cvtColor(_resize(im, self.size), cv2.COLOR_GRAY2BGR)).unsqueeze(
        0) for im in im_crops], dim=0).float()
2、
file: track.py
err reasons:  variable
correct: change
   visualize = increment_path(save_dir / Path(path).stem, mkdir=True) if opt.visualize else False
to 
   visualize = increment_path(save_path / Path(path).stem, mkdir=True) if opt.visualize else False