### PR TITLE
Timing report bug fix

### DIFF
--- a/track.py
+++ b/track.py
@@ -131,7 +131,7 @@ def detect(opt):
             save_path = str(Path(out) / Path(p).name)
 
             annotator = Annotator(im0, line_width=2, pil=not ascii)
-
+            t5 = t4 = 0
             if det is not None and len(det):
                 # Rescale boxes from img_size to im0 size
                 det[:, :4] = scale_coords(


### PR DESCRIPTION
When there aren't any detection in the first frame, the variables t4 and t5 were not initialized, this led to the following error when reporting DeepSort inference timings: 

_Traceback (most recent call last):
  File "track.py", line 244, in <module>
    detect(opt)
  File "track.py", line 180, in detect
    LOGGER.info(f'{s}Done. YOLO:({t3 - t2:.3f}s), DeepSort:({t5 - t4:.3f}s)')
UnboundLocalError: local variable 't5' referenced before assignment_

For any other frame with no detections, the reported DeepSort inference timing would be reported as the timing of the last frame with detections instead of 0